### PR TITLE
Fix PUT endpoint

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -29,7 +29,7 @@ nvm use v16
 NODE_ENV=production npm ci
 
 # Use pulumi to deploy project
-../scripts/infrastructure/deploy.sh
+./scripts/deploy.sh
 
 # Go back to Node version active when script ran
 nvm use $CURRENT_NODE

--- a/src/v1-jokes-handler/index.ts
+++ b/src/v1-jokes-handler/index.ts
@@ -53,7 +53,7 @@ const processRandomRequest = (
 const processUnknownRequest = (event: APIGatewayEvent): APIGatewayEventResult =>
   handleErrorWithDefault(status.BAD_REQUEST)(new Error(`handler received unexpected resource ${event.resource}`))
 
-export const processRequest: APIGatewayEventHander = async (event: APIGatewayEvent): Promise<APIGatewayEventResult> =>
+export const processRequest: APIGatewayEventHander = (event: APIGatewayEvent): Promise<APIGatewayEventResult> =>
   Promise.resolve(processOptionsRequest(event))
     .then((response) => response ?? processIdRequest(getReferenceInfo(), event))
     .then((response) => response ?? processPlainRequest(getReferenceInfo(), event))

--- a/src/v1-jokes-handler/v1-jokes-by-id.ts
+++ b/src/v1-jokes-handler/v1-jokes-by-id.ts
@@ -21,9 +21,7 @@ const putJokeFromData = (requestJokeId: number, jokeInfo: Joke): Promise<APIGate
   setDataByIndex(requestJokeId, { joke: jokeInfo.joke }).then(() => status.NO_CONTENT)
 
 export const putById = (requestJokeId: number, jokeInfo: Joke): Promise<APIGatewayEventResult> =>
-  Promise.resolve(!jokeInfo.joke ? status.BAD_REQUEST : undefined).then(
-    (response) => response ?? putJokeFromData(requestJokeId, jokeInfo)
-  )
+  jokeInfo.joke ? putJokeFromData(requestJokeId, jokeInfo) : Promise.resolve(status.BAD_REQUEST)
 
 /* Delete */
 
@@ -57,7 +55,9 @@ const processGetById = (event: APIGatewayEvent, requestJokeId: number): Promise<
   event.httpMethod === 'GET' ? exports.getById(requestJokeId) : Promise.resolve(undefined)
 
 const processPutById = (event: APIGatewayEvent, requestJokeId: number): Promise<APIGatewayEventResult | undefined> =>
-  event.httpMethod === 'PUT' ? exports.putById(requestJokeId, getPayloadFromEvent(event)) : Promise.resolve(undefined)
+  event.httpMethod === 'PUT'
+    ? getPayloadFromEvent(event).then((payload) => exports.putById(requestJokeId, payload))
+    : Promise.resolve(undefined)
 
 const processDeleteById = (
   event: APIGatewayEvent,

--- a/test/v1-jokes-handler/v1-jokes-by-id.test.ts
+++ b/test/v1-jokes-handler/v1-jokes-by-id.test.ts
@@ -127,7 +127,8 @@ describe('v1-jokes-by-id', () => {
   })
 
   describe('processById', () => {
-    const event = { pathParameters: { jokeId: '1' }, httpMethod: 'GET' } as unknown as APIGatewayEvent
+    const index = 1
+    const event = { pathParameters: { jokeId: `${index}` }, httpMethod: 'GET' } as unknown as APIGatewayEvent
     const getById = jest.spyOn(v1JokesById, 'getById')
     const putById = jest.spyOn(v1JokesById, 'putById')
     const deleteById = jest.spyOn(v1JokesById, 'deleteById')
@@ -136,7 +137,7 @@ describe('v1-jokes-by-id', () => {
     const deleteReturnValue = { value: 'unique-deleteById-value714' } as unknown as APIGatewayEventResult
 
     beforeAll(() => {
-      ;(getPayloadFromEvent as jest.Mock).mockReturnValue(joke)
+      ;(getPayloadFromEvent as jest.Mock).mockResolvedValue(joke)
 
       getById.mockResolvedValue(getReturnValue)
       putById.mockImplementation(async (requestJokeId: number, jokeInfo: Joke) => {

--- a/test/v1-jokes-handler/v1-jokes-by-id.test.ts
+++ b/test/v1-jokes-handler/v1-jokes-by-id.test.ts
@@ -162,7 +162,7 @@ describe('v1-jokes-by-id', () => {
 
       const result = await processById(Promise.resolve(referenceInfo), tempEvent)
       expect(result).toEqual(getReturnValue)
-      expect(getById).toHaveBeenCalledTimes(1)
+      expect(getById).toHaveBeenCalledWith(index)
     })
 
     test('expect PUT to invoke putById', async () => {
@@ -171,7 +171,7 @@ describe('v1-jokes-by-id', () => {
 
       const result = await processById(Promise.resolve(referenceInfo), tempEvent)
       expect(result).toEqual(putReturnValue)
-      expect(putById).toHaveBeenCalledTimes(1)
+      expect(putById).toHaveBeenCalledWith(index, joke)
     })
 
     test('expect DELETE to invoke deleteById', async () => {
@@ -180,7 +180,7 @@ describe('v1-jokes-by-id', () => {
 
       const result = await processById(Promise.resolve(referenceInfo), tempEvent)
       expect(result).toEqual(deleteReturnValue)
-      expect(deleteById).toHaveBeenCalledTimes(1)
+      expect(deleteById).toHaveBeenCalledWith(index, referenceInfo)
     })
 
     test('expect status.BAD_REQUEST when httpMethod is unknown', async () => {


### PR DESCRIPTION
PUT endpoint was returning `BAD REQUEST` for good requests because `getPayloadFromEvent` returns a Promise. Further, the test for `putById` was only testing _that_ it was called, not the parameter values.